### PR TITLE
Add Context processor for active_apps

### DIFF
--- a/apps/accounts/views/core.py
+++ b/apps/accounts/views/core.py
@@ -7,6 +7,7 @@ from django.contrib.auth import authenticate, login
 from django.contrib.auth import logout
 from django.contrib import messages
 from django.utils.translation import ugettext_lazy as _
+from hhs_oauth_server.hhs_oauth_server_context import IsAppInstalled
 
 from ..forms import *
 from ..models import *
@@ -52,7 +53,8 @@ def request_developer_invite(request):
                   'You will be contacted by email when your '
                   'invitation is ready.'),
             )
-            if settings.TEMPLATE_MODE == "EXTAPI":
+            if IsAppInstalled('apps.extapi'):
+                # Installation Specific code
                 logger.debug("email to invite:%s" % invited_email)
                 issued_invite = issue_invite(invited_email, user_type="DEV")
                 if issued_invite:

--- a/apps/extapi/templates/extapi/intro_step1.html
+++ b/apps/extapi/templates/extapi/intro_step1.html
@@ -43,6 +43,15 @@
                 <li>
                     Activate your developer account
                 </li>
+                <li>You will recieve a series of emails. An Activation Email will provide
+                    an authorization code. Use this to create your Developer account.
+                </li>
+                <li>After Creating your account you will receive an email with an
+                    activation link. Use the Activation link to activate your account.
+                </li>
+                <li>You will now be able to login to your developer account.</li>
+
+
             </ul>
             </p>
 

--- a/apps/home/templates/index.html
+++ b/apps/home/templates/index.html
@@ -22,7 +22,8 @@
         <div class="container-fluid">
                 <div class="col-md-8">
 
-                {% if settings.TEMPLATE_MODE == "EXTAPI" %}
+                {% if "apps.extapi" in active_apps %}
+
                     {%  include "extapi/get_started.html" %}
                 {% endif %}
 

--- a/hhs_oauth_server/examples/wsgi_test.py
+++ b/hhs_oauth_server/examples/wsgi_test.py
@@ -54,8 +54,6 @@ if DEBUG and not sys.argv[1].lower() in SUPPRESS_PRINT:
     print("==========================================================")
     # APPLICATION_TITLE is set in .base
     print(APPLICATION_TITLE)
-    # SETTINGS_MODE should be set in base to DJANGO_SETTINGS_MODULE
-    print("Mode:", SETTINGS_MODE)
     print("running on", python_version())
     # We should add note to base.py to make sure
     # ADMINS and MANAGERS are set in the custom settings file

--- a/hhs_oauth_server/hhs_oauth_server_context.py
+++ b/hhs_oauth_server/hhs_oauth_server_context.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# vim: ai ts=4 sts=4 et sw=4
+
+"""
+hhs_oauth_server
+FILE: context
+Created: 8/24/16 1:10 PM
+
+File created by: ''
+
+Create a function that will perform a contextprocessor function and
+return a True or False based on whether an app is in settings.INSTALLED_APPS
+
+The purpose is to simplify Environment/Installation Specific code branching
+
+Installation Specific code should be islated to an app that is embedded
+in the list of installed apps.
+Custom HTML should be installed in the templates/{app_Name} folder inside
+the application.
+
+"""
+from django.conf import settings
+
+
+def IsAppInstalled(target_app=None):
+    """ Is an app in INSTALLED_APPS """
+
+    if target_app:
+        if target_app in settings.INSTALLED_APPS:
+            return True
+    # Return False if target_app is not defined
+    # or target_app is not found in INSTALLED_APPS
+    return False
+
+
+def active_apps(request):
+    """ Is app active in INSTALLED_APPS """
+
+    return {'active_apps': settings.INSTALLED_APPS}

--- a/hhs_oauth_server/settings/base.py
+++ b/hhs_oauth_server/settings/base.py
@@ -63,14 +63,6 @@ DEBUG = env('DJANGO_DEBUG', True)
 #           "         and set DJANGO_ALLOWED_HOSTS to "
 #           "valid host names")
 
-# TODO: maybe they should be commented out
-SETTINGS_MODE = os.environ.setdefault('DJANGO_SETTINGS_MODULE',
-                                      'hhs_oauth_server.settings.base')
-SETTINGS_MODE = SETTINGS_MODE.upper().split('.')
-SETTINGS_MODE = SETTINGS_MODE[-1]
-
-TEMPLATE_MODE = os.environ.setdefault('DJANGO_TEMPLATE_MODE', "EXTAPI")
-
 # apps and middlewares
 INSTALLED_APPS = [
     'django.contrib.admin',
@@ -110,20 +102,16 @@ INSTALLED_APPS = [
 
     # DOT must be installed after apps.dot_ext in order to override templates
     'oauth2_provider',
-
 ]
 
-# Add the app for site specific extensions
-# a module under apps folder should exist to match template_mode.
-# eg. TEMPLATE_MODE = BASE
-# Should have an app : apps.base
+# Add apps for Site/Installation specific implementation here:
+# The hhs_oauth_server.hhs_oauth_server_context
 
-if TEMPLATE_MODE:
-    # should we add a test for __init__.py in apps.{TEMPLATE_MODE}?
-    INSTALLED_APPS += [
-        # Site Specific based on TEMPLATE_MODE -----------------
-        'apps.' + TEMPLATE_MODE.lower(),
-    ]
+INSTALLATION_SPECIFIC_APPS = [
+    # Installation/Site Specific apps based on  -----------------
+    'apps.extapi',
+]
+INSTALLED_APPS += INSTALLATION_SPECIFIC_APPS
 
 # CorsMiddleware needs to come before Django's
 # CommonMiddleware if you are using Django's
@@ -147,6 +135,18 @@ CORS_ORIGIN_ALLOW_ALL = env('CORS_ORIGIN_ALLOW_ALL', True)
 
 ROOT_URLCONF = 'hhs_oauth_server.urls'
 
+# TEMPLATES.context_processor:
+# 'hhs_oauth_server.hhs_oauth_server_context.active_apps'
+# enables custom code to be branched in templates eg.
+#                 {% if "apps.extapi" in active_apps %}
+#
+#                     {%  include "extapi/get_started.html" %}
+#                 {% endif %}
+# Place all environment/installation specific code in a separate app
+# hhs_oauth_server.hhs_oauth_server_context.py also
+# includes IsAppInstalled to check for target_app in INSTALLED_APPS
+# This enables implementation specific code to be branched inside views and
+# functions.
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
@@ -159,6 +159,7 @@ TEMPLATES = [
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
                 'django_settings_export.settings_export',
+                'hhs_oauth_server.hhs_oauth_server_context.active_apps',
             ],
         },
     },
@@ -411,8 +412,6 @@ SETTINGS_EXPORT = [
     'APPLICATION_TITLE',
     'THEME',
     'STATIC_URL',
-    'SETTINGS_MODE',
-    'TEMPLATE_MODE',
     'MFA'
 ]
 

--- a/hhs_oauth_server/urls.py
+++ b/hhs_oauth_server/urls.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python
 # from django.conf import settings
 from django.conf.urls import include, url
-from django.conf import settings
 from django.contrib import admin
 from apps.accounts.views.oauth2_profile import user_self
 from apps.fhir.bluebutton.views.home import fhir_search_home
+from hhs_oauth_server.hhs_oauth_server_context import IsAppInstalled
 admin.autodiscover()
 
 urlpatterns = [
@@ -30,7 +30,7 @@ urlpatterns += [
     url(r'^create_test_account/', include('apps.fhir.testac.urls')),
 ]
 
-if settings.TEMPLATE_MODE.upper() == "EXTAPI":
+if IsAppInstalled("apps.extapi"):
     urlpatterns += [
         url(r'^extapi/', include('apps.extapi.urls')),
     ]


### PR DESCRIPTION
Create context processor for active_apps (returns list of INSTALLED_APPS)
Added Site/Installation Specific section that adds to INSTALLED_APPS:
INSTALLATION_SPECIFIC_APPS = [
    # Installation/Site Specific apps based on  -----------------
    'apps.extapi',
]
INSTALLED_APPS += INSTALLATION_SPECIFIC_APPS

- Removed TEMPLATE_MODE and SETTINGS_MODE from settings.base
- Documented changes in settings.base

- Modified Templates to use context processor:

     # 'hhs_oauth_server.hhs_oauth_server_context.active_apps'
     # enables custom code to be branched in templates eg.
     #                 {% if "apps.extapi" in active_apps %}
     #
     #                     {%  include "extapi/get_started.html" %}
     #                 {% endif %}

Modified code to use IsAppInstalled from hhs_oauth_server.hhs_oauth_server_context.py
eg. 

           if IsAppInstalled('apps.extapi'):
                # Installation Specific code
                issued_invite = issue_invite(invited_email, user_type="DEV")


 