### PR TITLE
Added create consent on AccessToken post_save

### DIFF
--- a/apps/accounts/models.py
+++ b/apps/accounts/models.py
@@ -3,6 +3,7 @@ import random
 import uuid
 
 from datetime import datetime, timedelta
+from django.utils import timezone
 
 from django.db import models
 from django.conf import settings
@@ -284,7 +285,8 @@ class ActivationKey(models.Model):
 class ValidPasswordResetKey(models.Model):
     user = models.ForeignKey(User)
     reset_password_key = models.CharField(max_length=50, blank=True)
-    expires = models.DateTimeField(default=datetime.now)
+    # switch from datetime.now to timezone.now
+    expires = models.DateTimeField(default=timezone.now)
 
     def __str__(self):
         return '%s for user %s expires at %s' % (self.reset_password_key,
@@ -293,7 +295,8 @@ class ValidPasswordResetKey(models.Model):
 
     def save(self, **kwargs):
         self.reset_password_key = str(uuid.uuid4())
-        now = datetime.now()
+        # use timezone.now() instead of datetime.now()
+        now = timezone.now()
         expires = now + timedelta(minutes=1440)
         self.expires = expires
 

--- a/apps/fhir/bluebutton/utils.py
+++ b/apps/fhir/bluebutton/utils.py
@@ -41,12 +41,12 @@ def request_call(request, call_url, fail_redirect="/"):
         r = requests.get(call_url)
 
     except requests.ConnectionError:
-        logger.debug('Problem connecting to FHIR Server')
+        # logger.debug('Problem connecting to FHIR Server')
         messages.error(request, 'FHIR Server is unreachable.')
         return HttpResponseRedirect(fail_redirect)
 
     if r.status_code in ERROR_CODE_LIST:
-        logger.debug("\nError Status Code:%s" % r.status_code)
+        # logger.debug("\nError Status Code:%s" % r.status_code)
         return error_status(r, r.status_code)
 
     return r
@@ -137,8 +137,8 @@ def add_params(srtc, key=None):
             else:
                 params_list = [params_list, ]
 
-            logger.debug('Parameters to add:%s' % params_list)
-            logger.debug('key to replace: %s' % key)
+            # logger.debug('Parameters to add:%s' % params_list)
+            # logger.debug('key to replace: %s' % key)
 
             add_params = []
             for item in params_list:
@@ -158,7 +158,7 @@ def add_params(srtc, key=None):
 
                     add_params.append(item)
 
-            logger.debug('Resulting additional parameters:%s' % add_params)
+            # logger.debug('Resulting additional parameters:%s' % add_params)
 
     return add_params
 
@@ -201,7 +201,7 @@ def concat_parms(front_part={}, back_part={}):
                     joined_parms[item_split[0]] = ''
 
     concat_parm = '?' + urlencode(joined_parms)
-    logger.debug("Concat_parm:%s" % concat_parm)
+    # logger.debug("Concat_parm:%s" % concat_parm)
     if concat_parm.startswith('?='):
         concat_parms = '?' + concat_parm[3:]
     else:
@@ -246,7 +246,7 @@ def build_params(get, srtc, key):
     # leading ? and parameters joined by &
     all_param = concat_parms(url_param, add_param)
 
-    logger.debug('Parameter (post block/add):%s' % all_param)
+    # logger.debug('Parameter (post block/add):%s' % all_param)
 
     # now we check for _format being specified. Otherwise we get back html
     # by default we will process json unless _format is already set.
@@ -640,13 +640,24 @@ def get_default_path(resource_name):
 
 
 def dt_patient_reference(user):
-    """ Get Patient Reference rom Crosswalk for user """
+    """ Get Patient Reference from Crosswalk for user """
 
+    if user:
+        patient = crosswalk_patient_id(user)
+        if patient:
+            return {'reference': patient}
+
+    return None
+
+
+def crosswalk_patient_id(user):
+    """ Get patient/id from Crosswalk for user """
+
+    # print("\ncrosswalk_patient_id User:%s" % user)
     try:
         patient = Crosswalk.objects.get(user=user)
         if patient.fhir_id:
-            ref = {"reference": patient.fhir_id}
-            return ref
+            return patient.fhir_id
 
     except Crosswalk.DoesNotExist:
         pass

--- a/apps/fhir/build_fhir/utils/utils_fhir_dt.py
+++ b/apps/fhir/build_fhir/utils/utils_fhir_dt.py
@@ -330,7 +330,6 @@ def dt_period(start_date=None, end_date=None):
     """ Create a Period Data Type
 
 {
-  // from Element: extension
   "start" : "<dateTime>", // C? Starting time with inclusive boundary
   "end" : "<dateTime>" // C? End time with inclusive boundary, if not ongoing
 }

--- a/apps/fhir/fhir_consent/__init__.py
+++ b/apps/fhir/fhir_consent/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'apps.fhir.fhir_consent.apps.fhir_consentConfig'

--- a/apps/fhir/fhir_consent/apps.py
+++ b/apps/fhir/fhir_consent/apps.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+from __future__ import unicode_literals
 from django.apps import AppConfig
 from django.utils.translation import ugettext_lazy as _
 # from apps.fhir.fhir_consent import signals
@@ -11,6 +13,6 @@ class fhir_consentConfig(AppConfig):
     verbose_name = _("fhir_consent")
 
     def ready(self):
-        # import apps.fhir.fhir_consent.signals  # NOQA
+        # import apps.fhir.fhir_consent.signals
         from apps.fhir.fhir_consent import signals  # NOQA
-        # import signals
+

--- a/apps/fhir/fhir_consent/apps.py
+++ b/apps/fhir/fhir_consent/apps.py
@@ -10,4 +10,6 @@ class fhir_consentConfig(AppConfig):
     verbose_name = _("fhir_consent")
 
     def ready(self):
-        import apps.fhir.fhir_consent.signals  # NOQA
+        # import apps.fhir.fhir_consent.signals  # NOQA
+        import fhir_consent.signals
+        

--- a/apps/fhir/fhir_consent/apps.py
+++ b/apps/fhir/fhir_consent/apps.py
@@ -1,14 +1,16 @@
 from django.apps import AppConfig
 from django.utils.translation import ugettext_lazy as _
-
+# from apps.fhir.fhir_consent import signals
 # Setting is required in __init__.py
 # default_app_config = 'apps.fhir.fhir_consent.apps.fhir_consentConfig'
 
 
 class fhir_consentConfig(AppConfig):
+    # name = 'apps.fhir.fhir_consent'
     name = 'apps.fhir.fhir_consent'
     verbose_name = _("fhir_consent")
 
     def ready(self):
-        import apps.fhir.fhir_consent.signals  # NOQA
-        # import fhir_consent.signals
+        # import apps.fhir.fhir_consent.signals  # NOQA
+        from apps.fhir.fhir_consent import signals  # NOQA
+        # import signals

--- a/apps/fhir/fhir_consent/apps.py
+++ b/apps/fhir/fhir_consent/apps.py
@@ -10,6 +10,5 @@ class fhir_consentConfig(AppConfig):
     verbose_name = _("fhir_consent")
 
     def ready(self):
-        # import apps.fhir.fhir_consent.signals  # NOQA
-        import fhir_consent.signals
-        
+        import apps.fhir.fhir_consent.signals  # NOQA
+        # import fhir_consent.signals

--- a/apps/fhir/fhir_consent/apps.py
+++ b/apps/fhir/fhir_consent/apps.py
@@ -1,9 +1,13 @@
 from django.apps import AppConfig
+from django.utils.translation import ugettext_lazy as _
+
+# Setting is required in __init__.py
+# default_app_config = 'apps.fhir.fhir_consent.apps.fhir_consentConfig'
 
 
-class fhir_consent_config(AppConfig):
-    name = 'fhir_consent'
-    verbose_name = "fhir consent recorder"
+class fhir_consentConfig(AppConfig):
+    name = 'apps.fhir.fhir_consent'
+    verbose_name = _("fhir_consent")
 
     def ready(self):
-        import fhir_consent.signals  # NOQA
+        import apps.fhir.fhir_consent.signals  # NOQA

--- a/apps/fhir/fhir_consent/apps.py
+++ b/apps/fhir/fhir_consent/apps.py
@@ -15,4 +15,3 @@ class fhir_consentConfig(AppConfig):
     def ready(self):
         # import apps.fhir.fhir_consent.signals
         from apps.fhir.fhir_consent import signals  # NOQA
-

--- a/apps/fhir/fhir_consent/models.py
+++ b/apps/fhir/fhir_consent/models.py
@@ -1,6 +1,6 @@
 from collections import OrderedDict
 
-from datetime import datetime
+# from datetime import datetime
 from django.conf import settings
 from django.db import models
 from django.utils import timezone
@@ -30,7 +30,10 @@ class fhir_Consent(models.Model):
         self.key += self.created.strftime('%Y-%m-%dT%H:%M.%S') + "]"
 
         if self.valid_until:
-            if self.valid_until <= datetime.now():
+            # print("\nChecking valid_until"
+            #       " still valid:%s\nType:%s" % (self.valid_until,
+            #                                   type(self.valid_until)))
+            if self.valid_until <= timezone.now():
                 if not self.revoked:
                     self.revoked = self.valid_until
 

--- a/apps/fhir/fhir_consent/signals.py
+++ b/apps/fhir/fhir_consent/signals.py
@@ -9,18 +9,25 @@ Created: 2/24/16 1:23 PM
 
 __author__ = 'Mark Scrimshire:@ekivemark'
 
+Requires entry in apps.py and __init__.py to enable write_consent
 
 """
-import json
+# import json
 import logging
 
 # from collections import OrderedDict
+from django.utils import timezone
 
 # from django.conf import settings
+from oauth2_provider.models import AccessToken
 
 from django.dispatch import receiver
 from django.db.models.signals import post_save
-from oauth2_provider.models import AccessToken
+
+from apps.fhir.build_fhir.utils.utils_fhir_dt import (dt_period,
+                                                      dt_instant)
+from apps.fhir.fhir_consent.views import rt_consent_directive_activate
+from apps.fhir.fhir_consent.models import fhir_Consent
 
 logger = logging.getLogger('hhs_server.%s' % __name__)
 
@@ -30,28 +37,64 @@ logger = logging.getLogger('hhs_server.%s' % __name__)
 
 @receiver(post_save, sender=AccessToken)
 def write_consent(sender, **kwargs):
-    print("\n==============")
-    print("\nIn the post_save")
-    logger.debug("\n=============================================\n"
-                 "Model post_save:%s" % sender)
-    logger.debug('\nSaved: {}'.format(kwargs['instance'].__dict__))
+    # logger.debug("\n=============================================\n"
+    #              "Model post_save:%s" % sender)
+    # logger.debug('\nSaved: {}'.format(kwargs['instance'].__dict__))
 
     A_Tkn = kwargs['instance'].__dict__
 
+    # print("\n\nKWARGS:%s" % kwargs)
     # Write Consent JSON
 
     # Write fhir_Consent
+    # print("\n\nA_Tkn:%s\n\n" % A_Tkn)
+    A_Usr = A_Tkn['_user_cache']
+
+    A_App = A_Tkn['_application_cache']
+    # print("App:%s" % A_App)
+    # print("App Name:%s" % A_App.name)
 
     friendly_language = "Beneficiary (%s) gave " \
-                        "[%s] permission to application " \
-                        "(%s)" % (str(A_Tkn['user_id']),
-                                  A_Tkn['scope'],
-                                  A_Tkn['_application_cache'].fhir_reference)
-    body = {"text": friendly_language}
-    result = "pending"
+                        "[%s] permission to " \
+                        "application (%s)" % (A_Tkn['_user_cache'],
+                                              A_Tkn['scope'],
+                                              A_App.__str__)
 
-    logger.debug("\nA_Tkn:%s\nBody:%s"
-                 "\njson:%s\nResult:%s" % (A_Tkn,
-                                           body,
-                                           json.dumps(body),
-                                           result))
+    consent_now = timezone.now()
+    # NOTE: dt_instant and dt_period create string representations of date
+    instant_now = dt_instant(consent_now)
+    instant_until = dt_instant(A_Tkn['expires'])
+    oauth_period = dt_period(instant_now, instant_until)
+
+    consent = rt_consent_directive_activate(A_Usr,
+                                            A_App.name,
+                                            friendly_language,
+                                            oauth_period,
+                                            A_Tkn['scope'])
+
+    try:
+        f_c = fhir_Consent.objects.get(user=A_Usr, application=A_App)
+        created = False
+    except fhir_Consent.DoesNotExist:
+        f_c = fhir_Consent()
+        f_c.user = A_Usr
+        f_c.application = A_App
+        f_c.consent = consent
+        f_c.valid_until = A_Tkn['expires']
+
+        f_c.save()
+        created = True
+
+    if created:
+        pass
+    else:
+        vid = int(f_c.consent['meta']['versionId'])
+        vid += 1
+        consent['meta']['versionId'] = str(vid)
+
+        f_c.consent = consent
+        f_c.revoked = None
+        f_c.valid_until = A_Tkn['expires']
+        f_c.save()
+
+    return

--- a/apps/fhir/fhir_consent/signals.py
+++ b/apps/fhir/fhir_consent/signals.py
@@ -12,7 +12,8 @@ __author__ = 'Mark Scrimshire:@ekivemark'
 Requires entry in apps.py and __init__.py to enable write_consent
 
 """
-# import json
+from __future__ import absolute_import
+from __future__ import unicode_literals
 import logging
 
 # from collections import OrderedDict

--- a/apps/fhir/fhir_consent/utils.py
+++ b/apps/fhir/fhir_consent/utils.py
@@ -18,8 +18,15 @@ def resource_from_scopes(oauth_permissions):
         resource_list = []
 
         for scope in oauth_permissions:
-            resource_action = scope['code'].split("/")
-            resource = resource_action[1].split(".")
+            # print("\nScope:%s" % scope)
+            if 'code' in scope:
+                resource_action = scope['code'].split("/")
+            else:
+                resource_action = scope.split("/")
+            if len(resource_action) > 1:
+                resource = resource_action[1].split(".")
+            else:
+                resource = resource_action
             if resource[0] in resource_list:
                 pass
             else:


### PR DESCRIPTION
Added __init__.py and apps.py to activate post_save signal to
create fhir_Consent record.
Tests create for ConsentDirective
Switched to Dstu2 ConsentDirective resource format

fixed timezone v datetime in PasswordReset to solve test error
Must use timezone.now() to deal with USE_TZ setting.
flake8 passes locally
tests pass locally