### PR TITLE
More patches to solve admin_static incorrectly formated.

### DIFF
--- a/hhs_oauth_server/settings/base.py
+++ b/hhs_oauth_server/settings/base.py
@@ -441,6 +441,7 @@ SETTINGS_EXPORT = [
     'APPLICATION_TITLE',
     'THEME',
     'STATIC_URL',
+    'STATIC_ROOT',
     'MFA'
 ]
 

--- a/templates/admin/base.html
+++ b/templates/admin/base.html
@@ -1,4 +1,4 @@
-{% load i18n static %}<!DOCTYPE html>
+{% load i18n admin_static %}<!DOCTYPE html>
 {% get_current_language as LANGUAGE_CODE %}{% get_current_language_bidi as LANGUAGE_BIDI %}
 <html lang="{{ LANGUAGE_CODE|default:"en-us" }}" {% if LANGUAGE_BIDI %}dir="rtl"{% endif %}>
 <head>


### PR DESCRIPTION
with {% load admin_static %} in template and S3 storage used.
{% static '{static filename}' %} gets presented as:
https://s3.amazonaws.com/{AWS_STORGAGE_BUCKET_NAME}/{static filename}/static
switching to {% load static %} and {% static '{path}' %} get presented as:
https://s3.amazonaws.com/{AWS_STORGAGE_BUCKET_NAME}/static/{static filename}