### PR TITLE
Temporarily add ALLOWED_HOSTS to settings decorator in base.py

### DIFF
--- a/hhs_oauth_server/settings/base.py
+++ b/hhs_oauth_server/settings/base.py
@@ -374,6 +374,7 @@ DEVELOPER_DOCS_TITLE = "Developer Documentation"
 # eg. {{ settings.APPLICATION_TITLE }}
 SETTINGS_EXPORT = [
     'DEBUG',
+    'ALLOWED_HOSTS',
     'APPLICATION_TITLE',
     'THEME',
     'STATIC_URL',

--- a/templates/admin/auth/user/change_password.html
+++ b/templates/admin/auth/user/change_password.html
@@ -1,5 +1,5 @@
 {% extends "admin/base_site.html" %}
-{% load i18n static %}
+{% load i18n admin_static %}
 {% load admin_urls %}
 
 {% block extrahead %}{{ block.super }}

--- a/templates/admin/base.html
+++ b/templates/admin/base.html
@@ -1,4 +1,4 @@
-{% load i18n static %}<!DOCTYPE html>
+{% load i18n admin_static %}<!DOCTYPE html>
 {% get_current_language as LANGUAGE_CODE %}{% get_current_language_bidi as LANGUAGE_BIDI %}
 <html lang="{{ LANGUAGE_CODE|default:"en-us" }}" {% if LANGUAGE_BIDI %}dir="rtl"{% endif %}>
 <head>

--- a/templates/include/footer.html
+++ b/templates/include/footer.html
@@ -21,6 +21,6 @@
                 </div>
         </div>
         
-        
+       <div><small>{% if settings.ALLOWED_HOSTS %}{{ settings.ALLOWED_HOSTS|last }}{% endif %}</small></div>
   </div>
 </div><!-- /.container-fluid -->


### PR DESCRIPTION
Added settings.ALLOWED_HOSTS|Last in footer.htl to display server that code is running on. This is to help debugging and quick patching.

Done as part of solving admin static file issue with S3. Admin static files are being /static terminated and not displaying correctly.
This is an S3 problem because files are presented correctly locally.